### PR TITLE
Updated build -> build:js

### DIFF
--- a/.templates/new-module/package.json
+++ b/.templates/new-module/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/animate/package.json
+++ b/packages/animate/package.json
@@ -32,7 +32,7 @@
 		"serve": "browser-sync tests --files \"tests/**/*.html, tests/**/*.css, tests/**/*.js\"",
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -34,7 +34,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -34,7 +34,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/callout/package.json
+++ b/packages/callout/package.json
@@ -36,7 +36,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/control-input/package.json
+++ b/packages/control-input/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/cta-link/package.json
+++ b/packages/cta-link/package.json
@@ -35,7 +35,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/direction-links/package.json
+++ b/packages/direction-links/package.json
@@ -38,7 +38,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -35,7 +35,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/grid-12/package.json
+++ b/packages/grid-12/package.json
@@ -34,7 +34,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -34,7 +34,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/headings/package.json
+++ b/packages/headings/package.json
@@ -36,7 +36,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/inpage-nav/package.json
+++ b/packages/inpage-nav/package.json
@@ -36,7 +36,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/keyword-list/package.json
+++ b/packages/keyword-list/package.json
@@ -36,7 +36,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/link-list/package.json
+++ b/packages/link-list/package.json
@@ -35,7 +35,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/main-nav/package.json
+++ b/packages/main-nav/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/page-alerts/package.json
+++ b/packages/page-alerts/package.json
@@ -39,7 +39,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/progress-indicator/package.json
+++ b/packages/progress-indicator/package.json
@@ -32,7 +32,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/responsive-media/package.json
+++ b/packages/responsive-media/package.json
@@ -38,7 +38,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -34,7 +34,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/skip-link/package.json
+++ b/packages/skip-link/package.json
@@ -36,7 +36,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -34,7 +34,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {

--- a/packages/text-inputs/package.json
+++ b/packages/text-inputs/package.json
@@ -40,7 +40,7 @@
 
 		"watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
 		"watch:jsx": "onchange \"src/js/react.js\" \"tests/react/index.js\" -- npm run build",
-		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build",
+		"watch:sass": "onchange \"src/sass/*.scss\" \"tests/site/test.scss\" -- npm run build:js",
 		"watch": "npm run build && npm-run-all --parallel serve watch:*"
 	},
 	"pancake": {


### PR DESCRIPTION
Fixes #626 

Speeds up the `watch:sass` script a little bit by not running webpack also.