### PR TITLE
Update error colours to meet contrast on --alt backgrounds

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Versions
 
+* [v3.4.0 - Update error and success alert colours to meet contrast requirements on `--alt` backgrounds](#v340)
 * [v3.3.0 - Change error and success alert colours to make them accessible](#v330)
 * [v3.2.0 - Add additional colour checks for incaccesble color combinations](#v320)
 * [v3.1.2 - Removed uikit references](#v312)
@@ -40,6 +41,11 @@
 
 
 ## Release History
+
+### v3.4.0
+
+- Update error and success alert colours to meet contrast requirements on `--alt` backgrounds
+
 
 ### v3.3.0
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -255,6 +255,7 @@ The visual test: https://auds.service.gov.au/packages/core/tests/site/
 
 ## Release History
 
+* v3.4.0 - Update error and success alert colours to meet contrast requirements on `--alt` backgrounds
 * v3.3.0 - Change error and success alert colours to make them WCAG contrast requirements
 * v3.2.0 - Add additional colour checks for incaccesble color combinations
 * v3.1.2 - Removed uikit references

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/core",
-	"version": "3.3.0",
+	"version": "3.4.0",
 	"description": "The core module all components modules depend on",
 	"keywords": [
 		"auds",

--- a/packages/core/src/sass/_globals.scss
+++ b/packages/core/src/sass/_globals.scss
@@ -859,8 +859,8 @@ $AU-colordark-foreground-border: mix( $AU-colordark-foreground-text, $AU-colorda
 /**
  * Colors system messages
  */
-$AU-color-error:   #eb0000 !default;
-$AU-color-success: #0ca776 !default;
+$AU-color-error:   #d60000 !default;
+$AU-color-success: #0b996c !default;
 $AU-color-warning: #f69900 !default;
 $AU-color-info:    #00bfe9 !default;
 


### PR DESCRIPTION
We need to update these so they meet color contrast requirements on an `--alt` background, `#ebebeb`