### PR TITLE
fix but that AULinkList not respecting onClick properly

### DIFF
--- a/packages/link-list/src/js/react.js
+++ b/packages/link-list/src/js/react.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
  * @param  {object} li               - An additional object to be spread into the wrapping element, optional
  * @param  {object} attributeOptions - Any other attribute options, optional
  */
-export const AUlinkListItem = ({ text, link, linkComponent, li = {}, children, ...attributeOptions }) => {
+export const AUlinkListItem = ({ text, link, linkComponent, li = {}, children, onClick, ...attributeOptions }) => {
 	const LinkComponent = linkComponent;
 
 	// If there is no link provided and an onClick function


### PR DESCRIPTION
Hi Guys,

As we discussed in Slack channel I'm creating this PR. 

Post from Slack:

> Hi guys, I just found a bug in `AUlinkList` component which it doesn’t respect onClick property that I’m passing. It turns out in the component it compares `typeof onClick === 'function'` but in that line `onClick` variable is undefined.

Thanks