### PR TITLE
Add hint colours to `core`

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Versions
 
+* [v3.4.1 - Add two new colours: `hint-text` and `hint-text-alt`](#v341)
 * [v3.4.0 - Update error and success alert colours to meet contrast requirements on `--alt` backgrounds](#v340)
 * [v3.3.0 - Change error and success alert colours to make them accessible](#v330)
 * [v3.2.0 - Add additional colour checks for incaccesble color combinations](#v320)
@@ -41,6 +42,11 @@
 
 
 ## Release History
+
+### v3.4.1
+
+- Add two new colours: `hint-text` and `hint-text-alt`
+
 
 ### v3.4.0
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -255,6 +255,7 @@ The visual test: https://auds.service.gov.au/packages/core/tests/site/
 
 ## Release History
 
+* v3.4.1 - Add two new colours: `hint-text` and `hint-text-alt`.
 * v3.4.0 - Update error and success alert colours to meet contrast requirements on `--alt` backgrounds
 * v3.3.0 - Change error and success alert colours to make them WCAG contrast requirements
 * v3.2.0 - Add additional colour checks for incaccesble color combinations

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/core",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "The core module all components modules depend on",
 	"keywords": [
 		"auds",

--- a/packages/core/src/sass/_globals.scss
+++ b/packages/core/src/sass/_globals.scss
@@ -786,6 +786,7 @@ $AU-maxwidth: 42em !default; // Answer to life, the universe, and everything (ke
 $AU-color-foreground-text:   #313131 !default;
 $AU-color-foreground-action: #00698f !default;
 $AU-color-foreground-focus:  #9263DE !default;
+$AU-color-foreground-hint:   #6f777b !default;
 $AU-color-background:        #ffffff !default;
 
 
@@ -796,10 +797,11 @@ $AU-color-lowest-contrast: AU-color-lowest-contrast(
 
 
 // Override the background if it's not accessible and generate shades
-$AU-color-background:           AU-color-a11y( $AU-color-background, $AU-color-lowest-contrast );
-$AU-color-background-shade:     darken( $AU-color-background, 4% );
-$AU-color-background-alt:       darken( $AU-color-background, 8% );
-$AU-color-background-alt-shade: darken( $AU-color-background, 12% );
+$AU-color-background:              AU-color-a11y( $AU-color-background, $AU-color-lowest-contrast );
+$AU-color-background-shade:        darken( $AU-color-background, 4% );
+$AU-color-background-alt:          darken( $AU-color-background, 8% );
+$AU-color-background-alt-shade:    darken( $AU-color-background, 12% );
+$AU-color-foreground-alt-hint:     #61696B !default;
 
 
 // Generated border and muted colours


### PR DESCRIPTION
As updated in our sketch files in: https://github.com/govau/design-system-site/pull/516 we should add these colours to our `core` module and update `form`.

Issue: #735 