### PR TITLE
Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             mv index.html site/
             mv .deploy/manifest-staging.yml site/
             cd site/
-            cf login -a $CF_API_STAGING -o $CF_ORG_STAGING -s $CF_SPACE_STAGING -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
+            cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
             cf zero-downtime-push design-system-components -f manifest-staging.yml
 
 
@@ -82,7 +82,7 @@ jobs:
             mv index.html site/
             mv .deploy/manifest-testing.yml site/
             cd site/
-            cf login -a $CF_API_STAGING -o $CF_ORG_STAGING -s $CF_SPACE_STAGING -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
+            cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
             cf zero-downtime-push design-system-components-$CIRCLE_BRANCH -f manifest-testing.yml
 
 
@@ -103,7 +103,7 @@ jobs:
             mv index.html site/
             mv .deploy/manifest-production.yml site/
             cd site/
-            cf login -a $CF_API_PROD -o $CF_ORG_PROD -s $CF_SPACE_PROD -u $CF_USER_PROD -p $CF_PASSWORD_PROD
+            cf login -a $CF_API_PROD -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_PROD
             cf zero-downtime-push design-system-components -f manifest-production.yml
 
 

--- a/packages/buttons/package-lock.json
+++ b/packages/buttons/package-lock.json
@@ -4012,9 +4012,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",


### PR DESCRIPTION
Thanks @gordcorp !

```
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to make
it easier for us we need to have a standard naming convention for environment variables
across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use the
standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that
arent in the above list.
```