### PR TITLE
Fix spacing bug on class names card component

### DIFF
--- a/packages/card/CHANGELOG.md
+++ b/packages/card/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Versions
 
+* [v0.1.3 - Fix bug with spacing of class names in AUcard react component](#v013)
 * [v0.1.2 - Remove console log and update naming](#v012)
 * [v0.1.1 - Add background color to card](#v011)
 * [v0.1.0 - 💥 Initial version](#v010)
@@ -24,6 +25,11 @@
 
 
 ## Release History
+
+### v0.1.3
+
+- Fix bug with spacing of class names in AUcard react component
+
 
 ### v0.1.2
 

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -61,6 +61,7 @@ The visual test: https://auds.service.gov.au/packages/card/tests/site/
 
 ## Release History
 
+* v0.1.3 - Fix bug with spacing of class names in AUcard react component
 * v0.1.2 - Remove console log and update naming
 * v0.1.1 - Add background color to card
 * v0.1.0 - 💥 Initial version

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/card",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "A container for all types of content",
 	"keywords": [
 		"auds",

--- a/packages/card/src/js/react.js
+++ b/packages/card/src/js/react.js
@@ -31,7 +31,7 @@ const AUcard = ({ link, shadow, centred, clickable, className, children, ...attr
 	return (
 		<CardContainer className={`au-card ${className} ` +
 								`${shadow ? 'au-card--shadow' : ''} ` +
-								`${centred ? 'au-card--centred' : ''}` +
+								`${centred ? 'au-card--centred' : ''} ` +
 								`${clickable ? 'au-card--clickable' : ''}`}
 								{...attributesOptions}
 								>


### PR DESCRIPTION
Fixes spacing bug in css classes genereated by react props

![image](https://user-images.githubusercontent.com/20184809/59899760-3da85700-9439-11e9-8fd5-1ec0caea3499.png)
