### PR TITLE
Wrap accordion toggle buttons in a heading level

### DIFF
--- a/packages/accordion/CHANGELOG.md
+++ b/packages/accordion/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Versions
 
+* [v7.0.9 - Wrap toggle button in a heading level](#v709)
 * [v7.0.8 - Remove --save-dev flag from readme instructions](#v708)
 * [v7.0.7 - Removed unused `Fragment` React import](#v707)
 * [v7.0.6 - Resolve autoprefixer warning](#v706)
@@ -51,6 +52,11 @@
 
 
 ## Release History
+
+### v7.0.9
+
+- Wrap toggle button in a heading level [867] (https://github.com/govau/design-system-components/issues/867)
+
 
 ### v7.0.8
 

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -252,6 +252,7 @@ The visual test: https://auds.service.gov.au/packages/accordion/tests/site/
 
 ## Release History
 
+* v7.0.9 - Wrap toggle button in a heading level
 * v7.0.8 - Remove --save-dev flag from readme instructions
 * v7.0.7 - Removed unused `Fragment` React import
 * v7.0.6 - Resolve autoprefixer warning

--- a/packages/accordion/src/js/jquery.js
+++ b/packages/accordion/src/js/jquery.js
@@ -85,11 +85,11 @@ $.fn.AUaccordion = function( callbacks ) {
 					var speed = $( accordion ).attr('data-speed');
 
 					$( accordion )
-						.children('.js-au-accordion')
+						.children().children('.js-au-accordion')
 						.on('click', function( event ) {
 							event.preventDefault();
 
-							AU.accordion.Toggle( $( accordion ).children('.js-au-accordion')[ 0 ], speed, callbacks );
+							AU.accordion.Toggle( $( accordion ).children().children('.js-au-accordion')[ 0 ], speed, callbacks );
 						})
 						.addClass('js-au-accordion-rendered'); // marking as processed
 			});

--- a/packages/accordion/src/js/react.js
+++ b/packages/accordion/src/js/react.js
@@ -367,7 +367,7 @@ class AUaccordion extends React.PureComponent {
 	render() {
 		return (
 			<section className={ `au-accordion ${ this.className }${ this.props.dark ? ' au-accordion--dark' : '' }` } { ...this.attributeOptions }>
-				<h3>
+				<h4>
 					<button
 						className={`au-accordion__title js-au-accordion ${ this.closeClass }`}
 						aria-controls={ this.ID }
@@ -376,7 +376,7 @@ class AUaccordion extends React.PureComponent {
 						onClick={ ( event ) => this.toggle( event ) }>
 							{ this.props.header }
 					</button>
-				</h3>
+				</h4>
 				
 				<div
 					className={`au-accordion__body ${ this.closeClass }`}

--- a/packages/accordion/src/js/react.js
+++ b/packages/accordion/src/js/react.js
@@ -367,15 +367,17 @@ class AUaccordion extends React.PureComponent {
 	render() {
 		return (
 			<section className={ `au-accordion ${ this.className }${ this.props.dark ? ' au-accordion--dark' : '' }` } { ...this.attributeOptions }>
-				<button
-					className={`au-accordion__title js-au-accordion ${ this.closeClass }`}
-					aria-controls={ this.ID }
-					aria-expanded={ !this.props.closed }
-					ref={ accordionHeader => { this.accordionHeader = accordionHeader } }
-					onClick={ ( event ) => this.toggle( event ) }>
-						{ this.props.header }
-				</button>
-
+				<h3>
+					<button
+						className={`au-accordion__title js-au-accordion ${ this.closeClass }`}
+						aria-controls={ this.ID }
+						aria-expanded={ !this.props.closed }
+						ref={ accordionHeader => { this.accordionHeader = accordionHeader } }
+						onClick={ ( event ) => this.toggle( event ) }>
+							{ this.props.header }
+					</button>
+				</h3>
+				
 				<div
 					className={`au-accordion__body ${ this.closeClass }`}
 					id={ this.ID }>

--- a/packages/accordion/src/sass/_module.scss
+++ b/packages/accordion/src/sass/_module.scss
@@ -40,7 +40,7 @@
 			background-color: $AU-colordark-background-shade;
 		}
 	}
-	h3:first-child {
+	h1:first-child, h2:first-child, h3:first-child, h4:first-child, h5:first-child, h6:first-child {
 		margin: 0;
 	}
 }

--- a/packages/accordion/src/sass/_module.scss
+++ b/packages/accordion/src/sass/_module.scss
@@ -40,6 +40,9 @@
 			background-color: $AU-colordark-background-shade;
 		}
 	}
+	h3:first-child {
+		margin: 0;
+	}
 }
 
 .au-accordion + .au-accordion {

--- a/packages/accordion/tests/jquery/index.html
+++ b/packages/accordion/tests/jquery/index.html
@@ -63,9 +63,11 @@
 			<h3>Accordion open by default</h3>
 
 			<section class="au-accordion js-au-accordion-wrapper">
-				<button aria-controls="accordion-default" class="au-accordion__title js-au-accordion">
-					Accordion title
-				</button>
+				<h4>
+					<button aria-controls="accordion-default" class="au-accordion__title js-au-accordion">
+						Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-default">
 					<div class="au-accordion__body-wrapper">
@@ -81,9 +83,11 @@
 			<h3>Accordion closed by default</h3>
 
 			<section class="au-accordion js-au-accordion-wrapper">
-				<button aria-controls="accordion-closed" class="au-accordion__title au-accordion--closed js-au-accordion">
-					Accordion title
-				</button>
+				<h4>
+					<button aria-controls="accordion-closed" class="au-accordion__title au-accordion--closed js-au-accordion">
+						Accordion title
+					</button>
+				</h4>
 
 				<div class="js-au-accordion-body au-accordion__body au-accordion--closed" id="accordion-closed">
 					<div class="au-accordion__body-wrapper">
@@ -99,9 +103,11 @@
 			<h3>Accordion slow</h3>
 
 			<section class="au-accordion js-au-accordion-wrapper" data-speed="1000">
-				<button aria-controls="accordion-slow" class="au-accordion__title au-accordion--closed js-au-accordion">
-					Accordion title
-				</button>
+				<h4>
+					<button aria-controls="accordion-slow" class="au-accordion__title au-accordion--closed js-au-accordion">
+						Accordion title
+					</button>
+				</h4>
 
 				<div class="js-au-accordion-body au-accordion__body au-accordion--closed" id="accordion-slow">
 					<div class="au-accordion__body-wrapper">
@@ -116,9 +122,11 @@
 			<h3>Accordion with all callbacks</h3>
 
 			<section class="au-accordion js-au-accordion-wrapper-callbacks">
-				<button aria-controls="accordion-callbacks" class="au-accordion__title au-accordion--closed js-au-accordion">
-					Accordion title
-				</button>
+				<h4>
+					<button aria-controls="accordion-callbacks" class="au-accordion__title au-accordion--closed js-au-accordion">
+						Accordion title
+					</button>
+				</h4>
 
 				<div class="js-au-accordion-body au-accordion__body au-accordion--closed" id="accordion-callbacks">
 					<div class="au-accordion__body-wrapper">
@@ -137,9 +145,11 @@
 				<li>
 
 					<section class="au-accordion js-au-accordion-wrapper">
-						<button aria-controls="accordion-stacked1" class="au-accordion__title au-accordion--closed js-au-accordion">
-							First accordion title
-						</button>
+						<h4>
+							<button aria-controls="accordion-stacked1" class="au-accordion__title au-accordion--closed js-au-accordion">
+								First accordion title
+							</button>
+						</h4>
 
 						<div class="js-au-accordion-body au-accordion__body au-accordion--closed" id="accordion-stacked1">
 							<div class="au-accordion__body-wrapper">
@@ -147,9 +157,11 @@
 								<p>Here is some accordion content</p>
 
 								<section class="au-accordion js-au-accordion-wrapper">
-									<button aria-controls="inner-accordion" class="au-accordion__title au-accordion--open js-au-accordion">
-										A nested accordion
-									</button>
+									<h4>
+										<button aria-controls="inner-accordion" class="au-accordion__title au-accordion--open js-au-accordion">
+											A nested accordion
+										</button>
+									</h4>
 
 									<div class="js-au-accordion-body au-accordion__body au-accordion--open" id="inner-accordion">
 										<div class="au-accordion__body-wrapper">
@@ -170,9 +182,11 @@
 				<li>
 
 					<section class="au-accordion js-au-accordion-wrapper">
-						<button aria-controls="accordion-stacked2" class="au-accordion__title au-accordion--closed js-au-accordion">
-							Another accordion
-						</button>
+						<h4>
+							<button aria-controls="accordion-stacked2" class="au-accordion__title au-accordion--closed js-au-accordion">
+								Another accordion
+							</button>
+						</h4>
 
 						<div class="js-au-accordion-body au-accordion__body au-accordion--closed" id="accordion-stacked2">
 							<div class="au-accordion__body-wrapper">
@@ -187,9 +201,11 @@
 				<li>
 
 					<section class="au-accordion js-au-accordion-wrapper">
-						<button aria-controls="accordion-stacked3" class="au-accordion__title au-accordion--closed js-au-accordion">
-							Accordion with words and words and a very long title so that it can break into several
-						</button>
+						<h4>
+							<button aria-controls="accordion-stacked3" class="au-accordion__title au-accordion--closed js-au-accordion">
+								Accordion with words and words and a very long title so that it can break into several
+							</button>
+						</h4>
 
 						<div class="js-au-accordion-body au-accordion__body au-accordion--closed" id="accordion-stacked3">
 							<div class="au-accordion__body-wrapper">

--- a/packages/accordion/tests/site/index.html
+++ b/packages/accordion/tests/site/index.html
@@ -89,13 +89,15 @@
 			<h3>Accordion open by default</h3>
 
 			<section class="au-accordion">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-default"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this )">
-						Button Accordion title
-			</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-default"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this )">
+							Button Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-default">
 					<div class="au-accordion__body-wrapper">
@@ -111,14 +113,16 @@
 			<h3>Accordion closed by default</h3>
 
 			<section class="au-accordion">
-				<button
-					class="au-accordion__title au-accordion--closed js-au-accordion"
-					aria-controls="accordion-closed"
-					aria-expanded="false"
-					aria-selected="false"
-					onClick="return AU.accordion.Toggle( this )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title au-accordion--closed js-au-accordion"
+						aria-controls="accordion-closed"
+						aria-expanded="false"
+						aria-selected="false"
+						onClick="return AU.accordion.Toggle( this )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body au-accordion--closed" id="accordion-closed">
 					<div class="au-accordion__body-wrapper">
@@ -134,13 +138,15 @@
 			<h3>Accordion slow</h3>
 
 			<section class="au-accordion">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-slow"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this, 1000 )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-slow"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this, 1000 )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-slow">
 					<div class="au-accordion__body-wrapper">
@@ -156,26 +162,28 @@
 			<h3>Accordion with all callbacks</h3>
 
 			<section class="au-accordion">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-callbacks"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this, undefined, {
-						onOpen: function() {
-							console.log('This function will run when an accordion opens');
-						},
-						afterOpen: function() {
-							console.log('This function will run after an accordion has opened');
-						},
-						onClose: function() {
-							console.log('This function will run when an accordion closes');
-						},
-						afterClose: function() {
-							console.log('This function will run after an accordion has closed');
-						},
-					} )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-callbacks"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this, undefined, {
+							onOpen: function() {
+								console.log('This function will run when an accordion opens');
+							},
+							afterOpen: function() {
+								console.log('This function will run after an accordion has opened');
+							},
+							onClose: function() {
+								console.log('This function will run when an accordion closes');
+							},
+							afterClose: function() {
+								console.log('This function will run after an accordion has closed');
+							},
+						} )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-callbacks">
 					<div class="au-accordion__body-wrapper">
@@ -193,14 +201,16 @@
 			<ul class="au-accordion-group" aria-label="Group of Accordions">
 				<li>
 					<section class="au-accordion">
-						<button
-							class="au-accordion__title au-accordion--closed js-au-accordion"
-							aria-controls="accordion-stacked1"
-							aria-expanded="false"
-							aria-selected="false"
-							onClick="return AU.accordion.Toggle( this )">
-								First accordion title
-						</button>
+						<h4>
+							<button
+								class="au-accordion__title au-accordion--closed js-au-accordion"
+								aria-controls="accordion-stacked1"
+								aria-expanded="false"
+								aria-selected="false"
+								onClick="return AU.accordion.Toggle( this )">
+									First accordion title
+							</button>
+						</h4>
 
 						<div class="au-accordion__body au-accordion--closed" id="accordion-stacked1">
 							<div class="au-accordion__body-wrapper">
@@ -208,13 +218,15 @@
 								<p>Here is some accordion content</p>
 
 								<section class="au-accordion">
-									<button
-										class="au-accordion__title js-au-accordion"
-										aria-controls="inner-accordion"
-										aria-expanded="true"
-										onClick="return AU.accordion.Toggle( this )">
-											A nested accordion
-									</button>
+									<h4>
+										<button
+											class="au-accordion__title js-au-accordion"
+											aria-controls="inner-accordion"
+											aria-expanded="true"
+											onClick="return AU.accordion.Toggle( this )">
+												A nested accordion
+										</button>
+									</h4>
 
 									<div class="au-accordion__body" id="inner-accordion">
 										<div class="au-accordion__body-wrapper">
@@ -235,14 +247,16 @@
 
 				<li>
 					<section class="au-accordion">
-						<button
-							class="au-accordion__title au-accordion--closed js-au-accordion"
-							aria-controls="accordion-stacked2"
-							aria-expanded="false"
-							aria-selected="false"
-							onClick="return AU.accordion.Toggle( this )">
-								Another accordion
-						</button>
+						<h4>
+							<button
+								class="au-accordion__title au-accordion--closed js-au-accordion"
+								aria-controls="accordion-stacked2"
+								aria-expanded="false"
+								aria-selected="false"
+								onClick="return AU.accordion.Toggle( this )">
+									Another accordion
+							</button>
+						</h4>
 
 						<div class="au-accordion__body au-accordion--closed" id="accordion-stacked2">
 							<div class="au-accordion__body-wrapper">
@@ -256,14 +270,16 @@
 
 				<li>
 					<section class="au-accordion">
-						<button
-							class="au-accordion__title au-accordion--closed js-au-accordion"
-							aria-controls="accordion-stacked3"
-							aria-expanded="false"
-							aria-selected="false"
-							onClick="return AU.accordion.Toggle( this )">
-								Accordion with words and words and a very long title so that it can break into several
-						</button>
+						<h4>
+							<button
+								class="au-accordion__title au-accordion--closed js-au-accordion"
+								aria-controls="accordion-stacked3"
+								aria-expanded="false"
+								aria-selected="false"
+								onClick="return AU.accordion.Toggle( this )">
+									Accordion with words and words and a very long title so that it can break into several
+							</button>
+						</h4>
 
 						<div class="au-accordion__body au-accordion--closed" id="accordion-stacked3">
 							<div class="au-accordion__body-wrapper">
@@ -284,13 +300,15 @@
 				<h3>Accordion open by default</h3>
 
 				<section class="au-accordion">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-default-grid"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-default-grid"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-default-grid">
 						<div class="au-accordion__body-wrapper">
@@ -306,14 +324,16 @@
 				<h3>Accordion closed by default</h3>
 
 				<section class="au-accordion">
-					<button
-						class="au-accordion__title au-accordion--closed js-au-accordion"
-						aria-controls="accordion-closed-grid"
-						aria-expanded="false"
-						aria-selected="false"
-						onClick="return AU.accordion.Toggle( this )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title au-accordion--closed js-au-accordion"
+							aria-controls="accordion-closed-grid"
+							aria-expanded="false"
+							aria-selected="false"
+							onClick="return AU.accordion.Toggle( this )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body au-accordion--closed" id="accordion-closed-grid">
 						<div class="au-accordion__body-wrapper">
@@ -329,13 +349,15 @@
 				<h3>Accordion slow</h3>
 
 				<section class="au-accordion">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-slow-grid"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this, 1000 )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-slow-grid"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this, 1000 )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-slow-grid">
 						<div class="au-accordion__body-wrapper">
@@ -351,26 +373,28 @@
 				<h3>Accordion with all callbacks</h3>
 
 				<section class="au-accordion">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-callbacks-grid"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this, undefined, {
-							onOpen: function() {
-								console.log('This function will run when an accordion opens');
-							},
-							afterOpen: function() {
-								console.log('This function will run after an accordion has opened');
-							},
-							onClose: function() {
-								console.log('This function will run when an accordion closes');
-							},
-							afterClose: function() {
-								console.log('This function will run after an accordion has closed');
-							},
-						} )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-callbacks-grid"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this, undefined, {
+								onOpen: function() {
+									console.log('This function will run when an accordion opens');
+								},
+								afterOpen: function() {
+									console.log('This function will run after an accordion has opened');
+								},
+								onClose: function() {
+									console.log('This function will run when an accordion closes');
+								},
+								afterClose: function() {
+									console.log('This function will run after an accordion has closed');
+								},
+							} )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-callbacks-grid">
 						<div class="au-accordion__body-wrapper">
@@ -388,14 +412,16 @@
 				<ul class="au-accordion-group">
 					<li>
 						<section class="au-accordion">
-								<button
-									class="au-accordion__title au-accordion--closed js-au-accordion"
-									aria-controls="accordion-stacked-grid1"
-									aria-expanded="false"
-									aria-selected="false"
-									onClick="return AU.accordion.Toggle( this )">
-										First accordion title
-								</button>
+								<h4>
+									<button
+										class="au-accordion__title au-accordion--closed js-au-accordion"
+										aria-controls="accordion-stacked-grid1"
+										aria-expanded="false"
+										aria-selected="false"
+										onClick="return AU.accordion.Toggle( this )">
+											First accordion title
+									</button>
+								</h4>
 
 								<div class="au-accordion__body au-accordion--closed" id="accordion-stacked-grid1">
 									<div class="au-accordion__body-wrapper">
@@ -403,13 +429,15 @@
 										<p>Here is some accordion content</p>
 
 										<section class="au-accordion">
-											<button
-												class="au-accordion__title js-au-accordion"
-												aria-controls="inner-accordion-grid"
-												aria-expanded="true"
-												onClick="return AU.accordion.Toggle( this )">
-													A nested accordion
-											</button>
+											<h4>
+												<button
+													class="au-accordion__title js-au-accordion"
+													aria-controls="inner-accordion-grid"
+													aria-expanded="true"
+													onClick="return AU.accordion.Toggle( this )">
+														A nested accordion
+												</button>
+											</h4>
 
 											<div class="au-accordion__body" id="inner-accordion-grid">
 												<div class="au-accordion__body-wrapper">
@@ -428,14 +456,16 @@
 					</li>
 					<li>
 						<section class="au-accordion">
-								<button
-									class="au-accordion__title au-accordion--closed js-au-accordion"
-									aria-controls="accordion-stacked-grid2"
-									aria-expanded="false"
-									aria-selected="false"
-									onClick="return AU.accordion.Toggle( this )">
-										Another accordion
-								</button>
+								<h4>
+									<button
+										class="au-accordion__title au-accordion--closed js-au-accordion"
+										aria-controls="accordion-stacked-grid2"
+										aria-expanded="false"
+										aria-selected="false"
+										onClick="return AU.accordion.Toggle( this )">
+											Another accordion
+									</button>
+								</h4>
 
 								<div class="au-accordion__body au-accordion--closed" id="accordion-stacked-grid2">
 									<div class="au-accordion__body-wrapper">
@@ -448,14 +478,16 @@
 					</li>
 					<li>
 						<section class="au-accordion">
-							<button
-								class="au-accordion__title au-accordion--closed js-au-accordion"
-								aria-controls="accordion-stacked-grid3"
-								aria-expanded="false"
-								aria-selected="false"
-								onClick="return AU.accordion.Toggle( this )">
-									Accordion with words and words and a very long title so that it can break into several
-							</button>
+							<h4>
+								<button
+									class="au-accordion__title au-accordion--closed js-au-accordion"
+									aria-controls="accordion-stacked-grid3"
+									aria-expanded="false"
+									aria-selected="false"
+									onClick="return AU.accordion.Toggle( this )">
+										Accordion with words and words and a very long title so that it can break into several
+								</button>
+							</h4>
 
 							<div class="au-accordion__body au-accordion--closed" id="accordion-stacked-grid3">
 								<div class="au-accordion__body-wrapper">
@@ -479,13 +511,15 @@
 			<h3>Accordion open by default <code>--dark</code></h3>
 
 			<section class="au-accordion au-accordion--dark">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-dark-default"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-dark-default"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-dark-default">
 					<div class="au-accordion__body-wrapper">
@@ -501,14 +535,16 @@
 			<h3>Accordion closed by default <code>--dark</code></h3>
 
 			<section class="au-accordion au-accordion--dark">
-				<button
-					class="au-accordion__title au-accordion--closed js-au-accordion"
-					aria-controls="accordion-dark-closed"
-					aria-expanded="false"
-					aria-selected="false"
-					onClick="return AU.accordion.Toggle( this )">
-						Accordion title
-			</button>
+				<h4>
+					<button
+						class="au-accordion__title au-accordion--closed js-au-accordion"
+						aria-controls="accordion-dark-closed"
+						aria-expanded="false"
+						aria-selected="false"
+						onClick="return AU.accordion.Toggle( this )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body au-accordion--closed" id="accordion-dark-closed">
 					<div class="au-accordion__body-wrapper">
@@ -524,13 +560,15 @@
 			<h3>Accordion slow <code>--dark</code></h3>
 
 			<section class="au-accordion au-accordion--dark">
-			<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-dark-slow"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this, 1000 )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-dark-slow"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this, 1000 )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-dark-slow">
 					<div class="au-accordion__body-wrapper">
@@ -546,26 +584,28 @@
 			<h3>Accordion with all callbacks <code>--dark</code></h3>
 
 			<section class="au-accordion au-accordion--dark">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-dark-callbacks"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this, undefined, {
-						onOpen: function() {
-							console.log('This function will run when an accordion opens');
-						},
-						afterOpen: function() {
-							console.log('This function will run after an accordion has opened');
-						},
-						onClose: function() {
-							console.log('This function will run when an accordion closes');
-						},
-						afterClose: function() {
-							console.log('This function will run after an accordion has closed');
-						},
-					} )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-dark-callbacks"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this, undefined, {
+							onOpen: function() {
+								console.log('This function will run when an accordion opens');
+							},
+							afterOpen: function() {
+								console.log('This function will run after an accordion has opened');
+							},
+							onClose: function() {
+								console.log('This function will run when an accordion closes');
+							},
+							afterClose: function() {
+								console.log('This function will run after an accordion has closed');
+							},
+						} )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-dark-callbacks">
 					<div class="au-accordion__body-wrapper">
@@ -583,14 +623,16 @@
 			<ul class="au-accordion-group">
 				<li>
 					<section class="au-accordion au-accordion--dark">
-						<button
-							class="au-accordion__title au-accordion--closed js-au-accordion"
-							aria-controls="accordion-dark-stacked1"
-							aria-expanded="false"
-							aria-selected="false"
-							onClick="return AU.accordion.Toggle( this )">
-								First accordion title
-						</button>
+						<h4>
+							<button
+								class="au-accordion__title au-accordion--closed js-au-accordion"
+								aria-controls="accordion-dark-stacked1"
+								aria-expanded="false"
+								aria-selected="false"
+								onClick="return AU.accordion.Toggle( this )">
+									First accordion title
+							</button>
+						</h4>
 
 						<div class="au-accordion__body au-accordion--closed" id="accordion-dark-stacked1">
 							<div class="au-accordion__body-wrapper">
@@ -598,13 +640,15 @@
 								<p>Here is some accordion content</p>
 
 								<section class="au-accordion au-accordion--dark">
-									<button
-										class="au-accordion__title js-au-accordion"
-										aria-controls="inner-accordion-dark"
-										aria-expanded="true"
-										onClick="return AU.accordion.Toggle( this )">
-											A nested accordion
-									</button>
+									<h4>
+										<button
+											class="au-accordion__title js-au-accordion"
+											aria-controls="inner-accordion-dark"
+											aria-expanded="true"
+											onClick="return AU.accordion.Toggle( this )">
+												A nested accordion
+										</button>
+									</h4>
 
 									<div class="au-accordion__body" id="inner-accordion-dark">
 										<div class="au-accordion__body-wrapper">
@@ -625,14 +669,16 @@
 				</li>
 				<li>
 					<section class="au-accordion au-accordion--dark">
-						<button
-							class="au-accordion__title au-accordion--closed js-au-accordion"
-							aria-controls="accordion-dark-stacked2"
-							aria-expanded="false"
-							aria-selected="false"
-							onClick="return AU.accordion.Toggle( this )">
-								Another accordion
-						</button>
+						<h4>
+							<button
+								class="au-accordion__title au-accordion--closed js-au-accordion"
+								aria-controls="accordion-dark-stacked2"
+								aria-expanded="false"
+								aria-selected="false"
+								onClick="return AU.accordion.Toggle( this )">
+									Another accordion
+							</button>
+						</h4>
 
 						<div class="au-accordion__body au-accordion--closed" id="accordion-dark-stacked2">
 							<div class="au-accordion__body-wrapper">
@@ -646,14 +692,16 @@
 				<li>
 
 					<section class="au-accordion au-accordion--dark">
-						<button
-							class="au-accordion__title au-accordion--closed js-au-accordion"
-							aria-controls="accordion-dark-stacked3"
-							aria-expanded="false"
-							aria-selected="false"
-							onClick="return AU.accordion.Toggle( this )">
-								Accordion with words and words and a very long title so that it can break into several
-						</button>
+						<h4>
+							<button
+								class="au-accordion__title au-accordion--closed js-au-accordion"
+								aria-controls="accordion-dark-stacked3"
+								aria-expanded="false"
+								aria-selected="false"
+								onClick="return AU.accordion.Toggle( this )">
+									Accordion with words and words and a very long title so that it can break into several
+							</button>
+						</h4>
 
 						<div class="au-accordion__body au-accordion--closed" id="accordion-dark-stacked3">
 							<div class="au-accordion__body-wrapper">
@@ -674,13 +722,15 @@
 				<h3>Accordion open by default <code>--dark</code></h3>
 
 				<section class="au-accordion au-accordion--dark">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-dark-default-grid"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-dark-default-grid"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-dark-default-grid">
 						<div class="au-accordion__body-wrapper">
@@ -696,14 +746,16 @@
 				<h3>Accordion closed by default <code>--dark</code></h3>
 
 				<section class="au-accordion au-accordion--dark">
-					<button
-						class="au-accordion__title au-accordion--closed js-au-accordion"
-						aria-controls="accordion-dark-closed-grid"
-						aria-expanded="false"
-						aria-selected="false"
-						onClick="return AU.accordion.Toggle( this )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title au-accordion--closed js-au-accordion"
+							aria-controls="accordion-dark-closed-grid"
+							aria-expanded="false"
+							aria-selected="false"
+							onClick="return AU.accordion.Toggle( this )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body au-accordion--closed" id="accordion-dark-closed-grid">
 						<div class="au-accordion__body-wrapper">
@@ -719,13 +771,15 @@
 				<h3>Accordion slow <code>--dark</code></h3>
 
 				<section class="au-accordion au-accordion--dark">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-dark-slow-grid"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this, 1000 )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-dark-slow-grid"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this, 1000 )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-dark-slow-grid">
 						<div class="au-accordion__body-wrapper">
@@ -741,26 +795,28 @@
 				<h3>Accordion with all callbacks <code>--dark</code></h3>
 
 				<section class="au-accordion au-accordion--dark">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-dark-callbacks-grid"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this, undefined, {
-							onOpen: function() {
-								console.log('This function will run when an accordion opens');
-							},
-							afterOpen: function() {
-								console.log('This function will run after an accordion has opened');
-							},
-							onClose: function() {
-								console.log('This function will run when an accordion closes');
-							},
-							afterClose: function() {
-								console.log('This function will run after an accordion has closed');
-							},
-						} )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-dark-callbacks-grid"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this, undefined, {
+								onOpen: function() {
+									console.log('This function will run when an accordion opens');
+								},
+								afterOpen: function() {
+									console.log('This function will run after an accordion has opened');
+								},
+								onClose: function() {
+									console.log('This function will run when an accordion closes');
+								},
+								afterClose: function() {
+									console.log('This function will run after an accordion has closed');
+								},
+							} )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-dark-callbacks-grid">
 						<div class="au-accordion__body-wrapper">
@@ -778,14 +834,16 @@
 				<ul class="au-accordion-group">
 					<li>
 						<section class="au-accordion au-accordion--dark">
-							<button
-								class="au-accordion__title au-accordion--closed js-au-accordion"
-								aria-controls="accordion-dark-stacked-grid1"
-								aria-expanded="false"
-								aria-selected="false"
-								onClick="return AU.accordion.Toggle( this )">
-									First accordion title
-							</button>
+							<h4>
+								<button
+									class="au-accordion__title au-accordion--closed js-au-accordion"
+									aria-controls="accordion-dark-stacked-grid1"
+									aria-expanded="false"
+									aria-selected="false"
+									onClick="return AU.accordion.Toggle( this )">
+										First accordion title
+								</button>
+							</h4>
 
 							<div class="au-accordion__body au-accordion--closed" id="accordion-dark-stacked-grid1">
 								<div class="au-accordion__body-wrapper">
@@ -818,14 +876,16 @@
 					</li>
 					<li>
 						<section class="au-accordion au-accordion--dark">
-							<button
-								class="au-accordion__title au-accordion--closed js-au-accordion"
-								aria-controls="accordion-dark-stacked-grid2"
-								aria-expanded="false"
-								aria-selected="false"
-								onClick="return AU.accordion.Toggle( this )">
-									Another accordion
-						</button>
+							<h4>
+								<button
+									class="au-accordion__title au-accordion--closed js-au-accordion"
+									aria-controls="accordion-dark-stacked-grid2"
+									aria-expanded="false"
+									aria-selected="false"
+									onClick="return AU.accordion.Toggle( this )">
+										Another accordion
+								</button>
+							</h4>
 
 							<div class="au-accordion__body au-accordion--closed" id="accordion-dark-stacked-grid2">
 								<div class="au-accordion__body-wrapper">
@@ -838,14 +898,16 @@
 					</li>
 					<li>
 						<section class="au-accordion au-accordion--dark">
-							<button
-								class="au-accordion__title au-accordion--closed js-au-accordion"
-								aria-controls="accordion-dark-stacked-grid3"
-								aria-expanded="false"
-								aria-selected="false"
-								onClick="return AU.accordion.Toggle( this )">
-									Accordion with words and words and a very long title so that it can break into several
-							</button>
+							<h4>
+								<button
+									class="au-accordion__title au-accordion--closed js-au-accordion"
+									aria-controls="accordion-dark-stacked-grid3"
+									aria-expanded="false"
+									aria-selected="false"
+									onClick="return AU.accordion.Toggle( this )">
+										Accordion with words and words and a very long title so that it can break into several
+								</button>
+							</h4>
 
 							<div class="au-accordion__body au-accordion--closed" id="accordion-dark-stacked-grid3">
 								<div class="au-accordion__body-wrapper">
@@ -872,13 +934,15 @@
 			<h3>Accordion open by default on alt</h3>
 
 			<section class="au-accordion">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-alt"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-alt"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-alt">
 					<div class="au-accordion__body-wrapper">
@@ -892,13 +956,15 @@
 
 				<h3>Accordion open by default <code>--alt</code></h3>
 				<section class="au-accordion">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-body-alt"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-body-alt"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-body-alt">
 						<div class="au-accordion__body-wrapper">
@@ -916,13 +982,15 @@
 			<h3>Accordion <code>--dark</code> open by default on alt</h3>
 
 			<section class="au-accordion au-accordion--dark">
-				<button
-					class="au-accordion__title js-au-accordion"
-					aria-controls="accordion-altdark"
-					aria-expanded="true"
-					onClick="return AU.accordion.Toggle( this )">
-						Accordion title
-				</button>
+				<h4>
+					<button
+						class="au-accordion__title js-au-accordion"
+						aria-controls="accordion-altdark"
+						aria-expanded="true"
+						onClick="return AU.accordion.Toggle( this )">
+							Accordion title
+					</button>
+				</h4>
 
 				<div class="au-accordion__body" id="accordion-altdark">
 					<div class="au-accordion__body-wrapper">
@@ -936,13 +1004,15 @@
 
 				<h3>Accordion <code>--dark</code> open by default</h3>
 				<section class="au-accordion au-accordion--dark">
-					<button
-						class="au-accordion__title js-au-accordion"
-						aria-controls="accordion-body-altdark"
-						aria-expanded="true"
-						onClick="return AU.accordion.Toggle( this )">
-							Accordion title
-					</button>
+					<h4>
+						<button
+							class="au-accordion__title js-au-accordion"
+							aria-controls="accordion-body-altdark"
+							aria-expanded="true"
+							onClick="return AU.accordion.Toggle( this )">
+								Accordion title
+						</button>
+					</h4>
 
 					<div class="au-accordion__body" id="accordion-body-altdark">
 						<div class="au-accordion__body-wrapper">


### PR DESCRIPTION
Addresses #867 - wrapping accordion toggle buttons in a heading level to improve accessibility.

A potential further improvement in React could be to make the heading levels dynamic - setting the starting heading level as a variable so it can be easily overridden with a different level if needed, and nested accordions could then inherit the next heading level down from their parent.