### PR TITLE
Fix incompatibility with latest react-router-dom

### DIFF
--- a/packages/link-list/src/js/react.js
+++ b/packages/link-list/src/js/react.js
@@ -42,9 +42,8 @@ export const AUlinkListItem = ({ text, link, linkComponent, li = {}, children, o
 	// If we are using a normal link
 	if( LinkComponent === 'a' ) {
 		attributeOptions.href = link;
-	}
-	// If we are using a link component
-	else if( typeof LinkComponent === 'function' ) {
+	} else {
+		// If we are using a link component
 		attributeOptions.to = link;
 	}
 


### PR DESCRIPTION
The AUlinkList component is not compatible with the latest react-router-dom at the moment because react-router-dom uses React.forwardRef to create their Link component. The returned component from React.forwardRef tests false with `typeof ... === 'function'`, so `link` doesn't get passed to the `to` prop.

As far as I understand, AUlinkList can only use either "a" or `Link`, so it can simply set `link` to `to` when LinkComponent is not "a".

Alternatively it can check whether LinkComponent is either Object or function, but I don't think it's necessary given how AUlinkList is used.