### PR TITLE
Fix #933 unsafe eval

### DIFF
--- a/packages/animate/src/js/module.js
+++ b/packages/animate/src/js/module.js
@@ -340,5 +340,5 @@ if( typeof module !== 'undefined' ) {
 if( typeof exports !== 'undefined' ) {
 	Object.defineProperty( exports, "__esModule", { value: true } );
 
-	eval('exports.default = AU');
+	exports.default = AU;
 }


### PR DESCRIPTION
Reported by @kozilla.
Eval appears to be causing failures with Content Security Policy headers.
This is the only place where eval is used.