### PR TITLE
Fix/puppeteer packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   # installing dependencies, building assets and deploying to staging
   build-and-test-auds:
     docker:
-      - image: circleci/node:12.19.0                      # NodeLTS as of 10/2020
+      - image: circleci/node:12.18.4                      # NodeLTS as of 10/2020
     working_directory: ~/auds
     steps:
       - checkout                                          # get the files from the repo (why would you ever not want the files????)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   # installing dependencies, building assets and deploying to staging
   build-and-test-auds:
     docker:
-      - image: circleci/node:10.15.3                      # NodeLTS as of 03/2019
+      - image: circleci/node:12.19.0                      # NodeLTS as of 10/2020
     working_directory: ~/auds
     steps:
       - checkout                                          # get the files from the repo (why would you ever not want the files????)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"inquirer": "6.2.2",
 		"jest-cli": "^24.7.1",
 		"lerna": "^3.14.1",
-		"node-sass": "^4.12.0",
+		"node-sass": "^4.14.0",
 		"pa11y": "^5.1.0",
 		"postcss": "^7.0.14",
 		"puppeteer": "^1.13.0",


### PR DESCRIPTION
Fixes #938 
- Version bump for circleci/node docker container to 12.18.4 (latest available ActiveLTS version on DockerHub)
- Version bump for node-sass to ^4.14.0
