### PR TITLE
Hotfix 1001

### DIFF
--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -38,6 +38,12 @@ const CreateDir = ( dir ) => {
 		if( subPath != '.' ) {
 			currentPath = `${ path }/${ subPath }`;
 
+			//fix for #1001 Scaffold build process fails on Windows machine
+			if(currentPath.startsWith('/'))
+			{
+				currentPath = currentPath.substring(1);
+			}	
+
 			if( !Fs.existsSync( currentPath ) ){
 				Fs.mkdirSync( currentPath );
 			}

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -39,7 +39,7 @@ const CreateDir = ( dir ) => {
 			currentPath = `${ path }/${ subPath }`;
 
 			//fix for #1001 Scaffold build process fails on Windows machine
-			if(currentPath.startsWith('/'))
+			if(process.platform === "win32")
 			{
 				currentPath = currentPath.substring(1);
 			}	


### PR DESCRIPTION
Fix for `helper.js` causing the scaffolding build process (`npm run scaffolding`) to fail on Windows machines.