### PR TITLE
HotFix 1007

### DIFF
--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -39,7 +39,8 @@ const CreateDir = ( dir ) => {
 			currentPath = `${ path }/${ subPath }`;
 
 			//fix for #1001 Scaffold build process fails on Windows machine
-			if(process.platform === "win32")
+			//fix for #1007 Component build process fails on Windows machine
+			if((process.platform === "win32") && (currentPath.substring(0) == "/"))
 			{
 				currentPath = currentPath.substring(1);
 			}	


### PR DESCRIPTION
Fix for `helper.js` causing the component build process (`npm run build`) to fail on Windows machines.